### PR TITLE
Support for KDC & formula defaults instead of pillars

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ Configures the krb5.conf file.
 ------------
 
 Deploys keytab files.
+
+``kerberos.kdc``
+------------
+
+Basic support for Kerberos V5 domain controllers (KDC).

--- a/kerberos/config.sls
+++ b/kerberos/config.sls
@@ -1,5 +1,8 @@
 {% from "kerberos/map.jinja" import kerberos with context %}
 
+{% if kerberos.libdefaults is defined or kerberos.realms is defined %}
+#legacy pillar structure
+
 /etc/krb5.conf:
   file.managed:
     - user: root
@@ -7,3 +10,17 @@
     - group: {{ kerberos.get('root_group', 'root') }}
     - mode: 644
     - template: jinja
+
+{% else %}
+#updated pillar structure or no pillars defined
+
+kerberos-krb5-config:
+  file.managed:
+    - name: {{ kerberos.krb5.client_config }}
+    - source: salt://kerberos/files/krb5.conf
+    - user: root
+    - group: {{ kerberos.get('krb5:root_group', 'root') }}
+    - mode: 644
+    - template: jinja
+
+{% endif %}

--- a/kerberos/defaults.yaml
+++ b/kerberos/defaults.yaml
@@ -1,0 +1,73 @@
+# Default lookup dictionary for Kerberos V5
+kerberos:
+  krb5:
+    client_config: /etc/krb5.conf
+    client_config_src: salt://kerberos/files/krb5.conf
+    libdefaults:
+      default_realm: EXAMPLE.COM
+      default_domain: example.com
+      dns_lookup_kdc: false
+      dns_lookup_realm: yes
+      ticket_lifetime: 25h 
+      renew_lifetime: 120h
+      forwardable: true
+      rdns: false
+      default_ccache_name: 'KEYRING:persistent:%{uid}'
+      clockskew: 1m
+      proxiable: true
+      dns_lookup_kdc: true
+      allow_weak_crypto: false
+    realms:
+      EXAMPLE.COM:
+        kdc:
+          - primary-dc.example.com
+          - slave-dc.example.com
+        admin_server: primary-dc.example.com
+        master_kdc: primary-dc.example.com
+        slave_kdc: slave-dc.example.com
+        default_principal_flags = +preauth
+    domain_realm:
+      .example.com: EXAMPLE.COM
+      example.com: EXAMPLE.COM
+    capaths:
+    appdefaults:
+
+  kdc:
+    default_master: primary-dc.example.com
+    default_slave: primary-dc.example.com
+    config: /var/kerberos/krb5kdc/kdc.conf
+    config_src: salt://kerberos/files/kdc.conf
+    kprop_acl_file: /var/kerberos/krb5kdc/kpropd.acl
+    kprop_acl_file_src: salt://kerberos/files/kpropd.acl
+    kadm5_acl_file_src: salt://kerberos/files/kadm5.acl
+    default_keytab: /etc/krb5/krb5.keytab
+    dict_file: /usr/share/dict/words
+    kdb_util_create: /usr/sbin/kdb5_util create -s
+    compat_service: krb524d
+    kprop_service: kprop
+
+    kdcdefaults:
+      kdc_ports: 88
+      kdc_listen: 88
+      kdc_tcp_ports: 88
+      kdc_tcp_listen: 88
+    realms:
+      #supported_enctypes: 'aes256-cts:normal aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal camellia256-cts:normal camellia128-cts:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal'
+      #database_name: /usr/local/var/krb5kdc/principal
+      #key_stash_file: /usr/local/var/krb5kdc/.EXAMPLE.COM
+      acl_file: /var/kerberos/krb5kdc/kadm5.acl
+      kdc_listen: 88
+      kdc_tcp_listen: 88
+      max_life: 10h 0m 0s
+      max_renewable_life: 7d 0h 0m 0s
+    dbdefaults:
+    dbmodules:
+    otp:
+    logging:
+      kdc: 'FILE:/var/log/krb5kdc.log'
+      admin_server: 'FILE:/var/log/kadmin.log'
+      default: 'FILE:/var/log/krb5lib.log'
+
+    keytabs:
+      - dummy.keytab
+

--- a/kerberos/files/kadm5.acl
+++ b/kerberos/files/kadm5.acl
@@ -1,0 +1,19 @@
+#######################################################################
+# This file is managed by salt. Manual changes risk being overwritten. 
+# The contents of an example skeleton kdc.conf are stored at the       
+# bottom as a quick reference.                                         
+#######################################################################
+
+# This file is the access control list for krb5 administration.
+# When this file is edited restart the kadm server to activiate.
+# One common way to set up Kerberos administration is to allow any principal
+# ending in /admin is given full administrative rights.
+# To enable this, uncomment the following line:
+
+*/admin@{{ default_realm }}  *
+
+{# Future #}
+{# from "kerberos/map.jinja" import kerberos with context #}
+{#- for user in kerberos.kdc.users #}
+{#      .... process users #}
+{#- endfor -#}

--- a/kerberos/files/kdc.conf
+++ b/kerberos/files/kdc.conf
@@ -1,0 +1,167 @@
+{% raw %}
+#######################################################################
+# This file is managed by salt. Manual changes risk being overwritten. 
+# The contents of an example skeleton kdc.conf are stored at the       
+# bottom as a quick reference.                                         
+#######################################################################
+{% endraw %}
+
+{%- macro makeoutput(outdict) -%}
+  {%- for key, value in outdict|dictsort -%}
+  {{ output(key, value) }}
+  {%- endfor %}
+{%- endmacro -%}
+
+{%- macro output(key, value, spaces=0) -%}
+  {%- set shift = spaces * " " %}
+  {%- set newline = "\n" -%}
+  {%- if value is mapping %}
+    {{ shift }}{{ key }} = {
+    {%- for key, value in value|dictsort -%}
+    {{ output(key, value, spaces=spaces+4) }}
+    {%- endfor %}
+    {{ shift }}}
+  {%- elif key == '#' -%}
+    {{ newline }}{{ key }} {{ value }}
+  {%- elif value is string or value is number %}
+    {{ shift }}{{ key }} = {{ value }}
+  {%- elif value -%}
+    {%- for value in value -%}
+    {{ output(key, value, spaces=spaces) }}
+    {%- endfor %}
+  {%- endif %}
+{%- endmacro -%}
+
+{%- macro comment(str) -%}
+  {{ output("#", str) }}
+{%- endmacro -%}
+
+{% from "kerberos/map.jinja" import kerberos with context %}
+
+[kdcdefaults]
+  {%- set kdcdefaults = kerberos.kdc.get('kdcdefaults', {}) -%}
+  {{ makeoutput(kdcdefaults) if kdcdefaults else comment('Using software defaults') }}
+
+[realms]
+  {%- set realms = kerberos.kdc.get('realms', {}) -%}
+  {{ makeoutput(realms) if realms else comment('Using software defaults') }}
+
+[dbdefaults]
+  {%- set dbdefaults = kerberos.kdc.get('dbdefaults', {}) -%}
+  {{ makeoutput(dbdefaults) if dbdefaults else comment('Using software defaults') }}
+
+[dbmodules]
+  {%- set dbmodules = kerberos.kdc.get('dbmodules', {}) -%}
+  {{ makeoutput(dbmodules) if dbmodules else comment('Using software defaults') }}
+
+[otp]
+  {%- set otp = kerberos.kdc.get('otp', {}) -%}
+  {{ makeoutput(otp) if otp else comment('Using software defaults') }}
+
+[logging]
+  {%- set logging = kerberos.kdc.get('logging', {}) -%}
+  {{ makeoutput(logging) if logging else comment('Using software defaults') }}
+
+#
+# skeleton kdc.conf for reference
+#
+# This kdc.conf can be used to control the listening ports of the
+# KDC and kadmind, as well as realm-specific defaults, database type
+# and location, and logging. The file is used by KDC programs such as
+# the krb5kdc and kadmind daemons. Uses same format as krb5.conf file.
+
+#====================== kdcdefaults ==============================
+;[kdcdefaults]
+# Default values for KDC behavior
+#
+# Lists ports the Kerberos server should listen for UDP requests,
+# as comma-separated list of integers. The default value is 88, 750,
+# the assigned Kerberos port and port historically used by Kerberos V4.
+;kdc_ports = 88,750
+#
+# Lists ports the Kerberos server should listen for TCP connections,
+# as a comma-separated list of integers. If not specified, the
+# compiled-in default is not to listen for TCP connections at all.
+;kdc_tcp_ports = 88,750
+#
+# Name of the principal associated with the master key.
+;master_key_name = K/M
+#
+# Specifies the master keys key type.
+;master_key_type = aes256-cts-hmac-sha1-96
+#
+# KDC to reject ticket requests from anonymous principals to service
+# principals other than realms ticket-granting service (def: false).
+;restrict_anonymous_to_tgt = false
+#
+#How the KDC should respond to Kerberos 4 packets. Supported values
+# are none, disable, full, and nopreauth. Default value is none.
+;v4_mode = none
+#
+#======================= realms ==================================
+;[realms]
+# Realm-specific database configuration and settings
+;EXAMPLE.COM = {
+;      kdc_ports = 88
+;      kadmind_port = 749
+;      max_life = 12h 0m 0s
+;      max_renewable_life = 7d 0h 0m 0s
+;      master_key_type = des3-hmac-sha1
+;      default_principal_flags = +preauth
+;      supported_enctypes = arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
+#      If the default location does not suit your setup,
+#      explicitly configure the values below. Ensure write
+#      permission on the target directories (which must exist)
+;      #    admin_keytab = /etc/krb5/kadm5.keytab
+;      #    database_name = /var/kerberos/krb5kdc/principal
+;      #    acl_file = /var/kerberos/krb5kdc/kadm5.acl
+;      #    key_stash_file = /var/kerberos/krb5kdc/stash
+;}
+#
+#
+#====================== dbdefaults ===============================
+;[dbdefaults]
+# Default database settings
+;ldap_kerberos_container_dn = cn=krbcontainer, dc=example, dc=com
+;ldap_kerberos_container_dn = cn=krbcontainer, dc=hadoop, dc=example, dc=com
+#
+#
+#====================== dbmodules ================================
+;[dbmodules]
+# Per-database settings
+;   openldap_ldapconf = {
+;       db_library = kldap
+;       disable_last_success = true
+;       ldap_kdc_dn = "cn=krbadmin,dc=example,dc=com"
+;           # this object needs to have read rights on
+;           # the realm container and principal subtrees
+;       ldap_kadmind_dn = "cn=krbadmin,dc=example,dc=com"
+;           # this object needs to have read and write rights on
+;           # the realm container and principal subtrees
+;       ldap_service_password_file = /etc/kerberos/service.keyfile
+;       ldap_servers = ldaps://kerberos1.example.com
+;       ldap_conns_per_server = 5
+;   }
+#
+#
+#====================== logging ==================================
+;[logging]
+# Controls how Kerberos daemons perform logging. By default, KDC 
+# and kadmind log using syslog. You can override here.
+;   kdc = CONSOLE
+;   kdc = SYSLOG:INFO:DAEMON
+;   kdc = FILE:/var/log/krb5kdc.log
+;   admin_server = FILE:/var/log/kadmin.log
+;   admin_server = DEVICE=/dev/tty04
+;   default = FILE:/var/log/krb5lib.log
+#
+#==========================otp ==================================
+;[otp]
+# Support for onetime password requests. MIT Kerberos only
+;  MyRemoteTokenType = {
+;      # Server to send the RADIUS request to.
+;      server = 
+;      timeout =
+;      retries = 3
+;      strip_realm = true
+;  }

--- a/kerberos/files/kpropd.acl
+++ b/kerberos/files/kpropd.acl
@@ -1,0 +1,8 @@
+#######################################################################
+# This file is managed by salt. Manual changes risk being overwritten. 
+# The contents of an example skeleton kdc.conf are stored at the       
+# bottom as a quick reference.                                         
+#######################################################################
+
+host/{{ default_master }}@{{ default_realm }}
+host/{{ default_slave }}@{{ default_realm }}

--- a/kerberos/files/krb5.conf
+++ b/kerberos/files/krb5.conf
@@ -1,0 +1,420 @@
+{% raw %}
+#######################################################################
+# This file is managed by salt. Manual changes risk being overwritten. 
+# The contents of an example skeleton krb5.conf are stored at the
+# bottom as a quick reference.
+#######################################################################
+{% endraw %}
+
+{%- macro makeoutput(outdict) -%}
+  {%- for key, value in outdict|dictsort -%}
+  {{ output(key, value) }}
+  {%- endfor %}
+{%- endmacro -%}
+
+{%- macro output(key, value, spaces=0) -%}
+  {%- set shift = spaces * " " %}
+  {%- set newline = "\n" -%}
+  {%- if value is mapping %}
+    {{ shift }}{{ key }} = {
+    {%- for key, value in value|dictsort -%}
+    {{ output(key, value, spaces=spaces+4) }}
+    {%- endfor %}
+    {{ shift }}}
+  {%- elif key == '#' -%}
+    {{ newline }}{{ key }} {{ value }}
+  {%- elif value is string or value is number %}
+    {{ shift }}{{ key }} = {{ value }}
+  {%- elif value -%}
+    {%- for val in value -%}
+    {{ output(key, val, spaces=spaces) }}
+    {%- endfor %}
+  {%- endif %}
+{%- endmacro -%}
+
+{%- macro comment(str) -%}
+  {{ output("#", str) }}
+{%- endmacro -%}
+
+{%- from "kerberos/map.jinja" import kerberos with context -%}
+
+[libdefaults]
+  {%- set libdefaults = kerberos.krb5.get('libdefaults', {}) -%}
+  {{ makeoutput(libdefaults) if libdefaults else comment('Using software defaults') }}
+
+[realms]
+  {%- set realms = kerberos.krb5.get('realms', {}) -%}
+  {{ makeoutput(realms) if realms else comment('Using software defaults') }}
+
+[domain_realm]
+  {%- set domain_realm = kerberos.krb5.get('domain_realm', {}) -%}
+  {{ makeoutput(domain_realm) if domain_realm else comment('Using software defaults') }}
+
+[capaths]
+  {%- set capaths = kerberos.krb5.get('capaths', {}) -%}
+  {{ makeoutput(capaths) if capaths else comment('Using software defaults') }}
+
+[appdefaults]
+  {%- set appdefaults = kerberos.krb5.get('appdefaults', {}) -%}
+  {{ makeoutput(appdefaults) if appdefaults else comment('Using software defaults') }}
+
+[kadmin]
+  {%- set kadmin = kerberos.krb5.get('kadmin', {}) -%}
+  {{ makeoutput(kadmin) if kadmin else comment('Using software defaults') }}
+
+{# Logging belongs in kdc.conf not here. Retain for compatibility. #}
+[logging]
+  {%- set logging = kerberos.krb5.get('logging', {}) -%}
+  {{ makeoutput(logging) if logging else comment('See kdc.conf for logging defaults') }}
+
+
+#
+#  skeleton krb5.conf for reference
+#
+# This is the main Kerberos configuration file; see krb5.conf(5).
+# Lines beginning with ; (semi-colon) or # (hash) are ignored.
+# Rule: Comments (#) must begin from column 0.
+#
+# This file demonstrates sample configuration for both-
+# - MIT Kerberos: http://web.mit.edu/kerberos/www/
+# - Heimdal Kerberos: http://www.h5l.org/
+#
+# See also other implementations-
+# - Shishi Kerberos: http://www.gnu.org/software/shishi 
+# - Microsoft
+# - Sun Java
+#
+#
+#===================== libdefaults ================================
+# Contains default values used by the Kerberos V5 library.
+;[libdefaults]
+#
+# Default/local realm
+;default_realm = EXAMPLE.COM
+#
+# Allow weak crypto algorithms
+;allow_weak_crypto = false
+#
+# Max time differential between KDC and app servers (default 5m)
+;clockskew = 300
+#
+# Maximum wait time for reply from kdc, default 3 seconds.
+;kdc_timeout = 3
+#
+# The keytab to use if no other is specified.
+;default_keytab_name = FILE:/etc/krb5.keytab
+#
+# Behind a NAT, you may want to set to the NAT's public address
+;extra_addresses = ip.address.of.nat
+#
+# Obtain forwardable tickets for inital credentials (def: false)
+;forwardable = true
+#
+# Try to compensate for time diff between local machine and KDC.
+;kdc_timesync = true
+#
+# Do not use DNS TXT records to lookup domain-realm mappings.
+;dns_lookup_kdc = true
+;dns_lookup_realm = false
+#
+# For initial credentials, make credentials proxiable (def: false)
+;proxiable = true
+#
+# Enable if all KDC's are heimdal 0.6 or later (def: true)
+# or if you are behind a NAT (probably true).
+;no-addresses = true
+#
+# Default ticket lifetime to request (max: 1y?)
+;ticket_lifetime = 1d
+#
+# Default renewable ticket lifetime.
+;renew_lifetime = 7d
+#
+# Don't try to convert V4 instances to V5 using DNS resolution
+;v4_instance_resolve = false
+#
+# Fail to verify inital credentials if client machine has no
+# keytab. Some applications, like su(1), enable this anyway.
+;verify_ap_req_nofail = false
+#
+###### Java (JAAS) Kerberos ###########
+# By default, the Java Kerberos configuration uses the UDP
+# protocol. Otherwise the TCP protocol is used only if the
+# ticket request over UDP fails with KRB_ERR_RESPONSE_TOO_BIG.
+# To use TCP protocol as default specify '1' here.
+;udp_preference_limit =
+#
+###### HEIMDAL Kerberos only
+# Enable if all KDC's are heimdal 0.6 or later (def: true)
+# or if you are behind a NAT (probably true).
+;noaddresses = true
+#
+# sets the default credentials type (Heimdal Kerberos)
+;default_cc_type = 4
+#
+# sets default credentials cache name (Heimdal Kerberos).
+;default_cc_name =
+#
+# Override default encryption types. But this only serves to
+# disable new encryption types resulting in interop problems.
+;default_etypes =
+;default_as_etypes =
+;default_tgs_etypes =
+#
+# Parameter v4_name_convert is valid for Heidmal only.
+# See krb5_425_conv_principal(3) manual page.
+;v4_name_convert = {
+;    host = {
+;        rcmd    = host
+;        ftp     = ftp
+;        imap    = imap
+;        pop     = pop
+;        lmtp    = lmtp
+;        mupdate = mupdate
+;    }
+;    plain = {
+;        ftp    = ftp
+;        rcmd   = host
+;        hprop  = hprop
+;        iprop  = iprop
+;        ldap   = ldap 
+;        smtp   = smtp 
+;    }
+#
+#Set to true for Heimdal 0.6 or earlier
+;fcc-mit-ticketflags = false
+#
+# The max number of times to try to contact each KDC.
+;max_retries = number
+#
+# How soon to warn for expiring password. Default 7-days.
+;warn_pwexpire = time
+#
+# Write log-entries using UTC instead of local time zone.
+;log_utc = false
+#
+# When deciding what addresses to ask for in a ticket, list
+# addresses belonging to any interface on this host.
+;scan_interfaces = true
+#
+# Use file credential cache format version specified. On
+# machines running old Oracle krb5 code, uncomment this,
+;fcache_version = 3
+#
+#
+###### MIT Kerberos only
+# Accept diff client principals than requested (def: false)
+;canonicalize = false
+#
+# sets the default credentials type.
+;ccache_type = 4
+#
+; Default KDC options (Xored) (def: 0x00000010, KDC_OPT_RENEWABLE_OK)
+;kdc_default_options = 0x00000010
+#
+# sets default credentials cache name.
+;default_ccache_name = FILE:/tmp/krb5cc_%{uid}
+#
+# name of default keytab for getting client credentials.
+;default_client_keytab_name = FILE:/var/kerberos/krb5/user/%{euid}/client.keytab
+#
+# The following encryption types are used by MIT Kerberos if set.
+# However MIT defaults are generally correct so overriding
+# only disables new encryption types, creating interop problems.
+;default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4
+;default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4
+;permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4
+#
+;dns_canonicalize_hostname = true
+#
+;kcm_mach_service = org.h5l.kcm
+;kcm_socket = /var/run/.heim_org.h5l.kcm-socket
+#
+;EXAMPLE.COM = {
+;  pkinit_anchors = FILE:/usr/local/example.com.crt
+; }
+;pkinit_anchors = DIR:/usr/local/generic_trusted_cas/
+#
+#
+#================ login section =======================
+# Referenced by MIT kerberos v5 web docs but omitted
+# from krb5.conf(5) man page. Not documented by Heimdal.
+;[login]
+# Use user's password to get V5 tickets (def: true)
+;krb5_get_tickets = true
+# Use user's password to get V4 tickets (def: false)
+;krb4_get_tickets = false
+# Use Kerberos conversion daemon to get V4 tickets (def: false)
+;krb4_convert = false
+# Run aklog (def: false) 
+;krb_run_aklog = false
+# Location of aklog (default value is $(prefix)/bin/aklog )
+;aklog_path =
+# True causes login to reject plaintext passwords (def: false)
+;accept_passwd = false-not-implemented-yet
+#
+#
+#================ appdefaults section =====================
+# Contains default values usable by Kerberos V5 applications.
+;[appdefaults]
+#
+# MIT Kerberos advise you to review application man pages,
+# noting defaults here may be overridden in [realms] section.
+# Meanwhile Heimdal Kerberos documents the following-
+#
+;    pam: {
+#       Default ticket lifetime to request (max: 1y?)
+;       ticket_lifetime = 1d
+#
+#       Default renewable ticket lifetime.
+;       renew_lifetime = 1d
+#
+##       Obtain forwardable tickets on inital credentials (def: false)
+;       forwardable = true
+#
+#       For initial credentials, make them proxiable (def: false)
+;       proxiable = false
+#
+#       Are tickets valid from any address for initial creds. Enable
+#       if all KDC's are heimdal 0.6 or ipaddress is NAT'ed.
+;       no-addresses = true
+#
+#       Use encryption when available; Heidmal.
+;       encrypt = true
+#
+#       Forward creds to remote host (rsh, telnet, etc); Heidmal.
+;       forward = true
+#
+;       retain_after_close = false
+;       debug = false
+;       minimum_uid = 0
+;    }
+#
+#==================== realms ===============================
+;[realms]
+# Each tag names a Kerberos realm with relations defining
+# the properties of that particular realm. The following
+# tags may be specified in the realm's subsection:
+#
+;EXAMPLE.COM {
+#    Name of host running kerberos administration server.
+;    admin_server = kerberos1.example.com
+#
+#    This breaks krb4 compatibility but increases security
+;    default_principal_flags = +preauth
+#
+#    Name of master KDC. Used if credentials fail (maybe
+#    caused by "slow password-change propagation").
+;    master_kdc = kerberos1.example.com
+#
+#    Name of host(s) running a kdc for this realm.
+;    kdc = kerberos1.example.com
+;    kdc = kerberos2.example.com
+;    kdc = kerberos3.example.com
+;    kdc = kerberos4.example.com
+#
+#    Used for Kerberos 4 compatibility and translation.
+;    default_domain = example.com
+#
+#    Exceptions to default_domain mapping rule. Contains V4
+#    instances (tag name) translating to specific hostname (tag
+#    value) as second component in a Kerberos V5 principal name.
+;    v4_instance_convert = {
+;                kerberos = kerberos
+;                computer = computer.some.other.domain
+;             }
+#
+#    Used by krb524 library converting from V5 to V4 principal
+#    names. The tag value is the Kerberos V4 realm name.
+;    v4_realm = kerberos.olddomain.example.com
+#
+#    General rules mapping principal names to local user names
+;    auth_to_local = {
+;                 RULE:[2:$1](johndoe)s/^.*$/guest/
+;                 RULE:[2:$1;$2](^.*;admin$)s/;admin$//
+;                 RULE:[2:$2](^.*;root)s/^.*$/root/
+;                 DEFAULT
+;                 }
+#
+#    Explicit mappings from principal names to local user names
+;    auth_to_local_names = {
+;                 }
+#
+#    Host where password changes occur (def: <adm_server>:464)
+;    kpasswd_server = kerberos.example.com:464
+;}
+#
+;HADOOP.EXAMPLE.COM = {
+;    admin_server = kerberos1.hadoop.example.com
+;    kdc = kerberos1.hadoop.example.com
+;    kdc = kerberos2.hadoop.example.com
+;    default_domain = example.com
+;    pkinit_anchors = FILE:/usr/local/otherrealm.org.crt
+;}
+#
+#
+#======================== domain_realm ======================
+;[domain_realm]
+# Maps domain name or hostname to Kerberos realm name.
+;.example.com = EXAMPLE.COM
+;example.com = EXAMPLE.COM
+;.hadoop.example.com = HADOOP.EXAMPLE.COM
+;hadoop.example.com = HADOOP.EXAMPLE.COM
+#
+#
+#========================== plugins =========================
+;[plugins]
+# Referenced in MIT Kerberos krb5.conf(5) man page.
+# Controls dynamic plugin module registration.
+#
+#========================== kadmin ==========================
+# Documented in Hemidal krb5.conf(5). Omitted by MIT man page.
+;[kadmin]
+# Is pre-authentication required to talk to kadmin server?
+;require-preauth = false
+# If a principal already has its password set for expiration,
+# this is how long it remains valid after a change.
+;password_lifetime = 7d
+#
+#========================== capaths =========================
+;[capaths]
+# For direct (non-hierarchical) cross-realm authentication,
+# a database is required to construct authentication paths
+# between the realms. This section defines that database.
+#
+#
+#---------------------- Expandable tokens --------------------
+## Common
+# %{TEMP} is value of ${TMP} or ${TEMP} env variables (i.e. /tmp)
+# %{null} is empty string.
+# 
+## Heimdal
+# %{USERID} is string representation of user's SID.
+#
+## MIT
+# %{USERID} or %{uid} is Unix real UID or Windows SID
+# %{euid} is Unix effective user ID or Windows SID
+# %{BINDIR} is installation binary directory (distro def /usr/bin)
+# %{LIBDIR} is installation library directory (distro def /var/lib)
+# %{SBINDIR} is installation admin binary directory
+# %{username} is Unix Username of effective user ID
+# %{APPDATA} is Windows Roaming application data for current user
+# %{COMMON_APPDATA} is Windows application data for all users
+# %{LOCAL_APPDATA} is Windows local application data for current user
+# %{SYSTEM} is Windows system folder
+# %{WINDOWS} is Windows folder
+# %{USERCONFIG} Windows Per-user MIT krb5 config file directory
+# %{COMMOMCONFIG} is Windows common MIT krb5 config file directory 
+#
+#===================== Default paths ===============================================
+# Description              SymName       Custom build path      Typical distro path
+#...................................................................................
+# User programs            BINDIR        /usr/local/bin          /usr/bin
+# Libraries and plugins	   LIBDIR        /usr/local/lib          /usr/lib
+# Parent of KDC statedir   LOCALSTATEDIR /usr/local/var          /var
+# Parent of KDC runtimedir RUNSTATEDIR   /usr/local/var/run      /run
+# Administrative programs  SBINDIR       /usr/local/sbin         /usr/sbin
+# Alternate krb5.conf dir  SYSCONFDIR    /usr/local/etc          /etc
+# Default ccache name      DEFCCNAME     FILE:/tmp/krb5cc_%{uid} FILE:/tmp/krb5cc_%{uid}
+# Default keytab name      DEFKTNAME     FILE:/etc/krb5.keytab   FILE:/etc/krb5.keytab
+

--- a/kerberos/files/krb5.sh
+++ b/kerberos/files/krb5.sh
@@ -1,0 +1,24 @@
+#######################################################################
+# This file is managed by salt. Manual changes risk being overwritten. 
+# The contents of an example skeleton kdc.conf are stored at the       
+# bottom as a quick reference.                                         
+#######################################################################
+
+#TODO FUTURE
+#
+#Hemidal Kerberos only
+export KRB5CCNAME={{ krb5ccname }}
+export KRB5CCPRINCIPAL={{ krb5ccprincipal }}
+
+#MIT only
+export KRB5_KTNAME=<keytab-file>
+export KRB5_CLIENT_KTNAME=<client-keytab-file>
+export KRB5_KDC_PROFILE=<kdc-config-file>
+export KRB5RCACHEDIR=<tempdir>
+
+#Hemidal and MIT
+export KRB5HOME={{ krb5_home }}
+export KRB5_CONFIG={{ kr5b_config }}
+
+#Any implementation
+export PATH=${PATH}:${KRB5HOME}

--- a/kerberos/files/principals.awk
+++ b/kerberos/files/principals.awk
@@ -1,0 +1,36 @@
+#TODO - FUTURE MAYBE
+#
+# jinja2 contexts: 
+# - principals = dict of user:pass
+# - action = add
+# - kadmin_local = full path to kadmin.local binary
+#
+# TODO ......
+
+# Task 1: Pillar dictionary of principals/users
+#
+# kerberos:
+#   kdc:
+#     principals:
+#       ATHENA.MIT.EDU:
+#         steve:
+#           passwd: RfgpE2iQwD
+#           roles: admin
+#           action: add
+#         admin:
+#           passwd: RfgpE2iQwD
+#           roles: admin
+#           action: add
+
+# Task 2: Add to KDC method
+# See: https://docs.oracle.com/cd/E36784_01/html/E37126/aadmin-192.html for ideas
+#
+
+awk '{ print "ank +needchange -pw", $2, $1 }' << EOF
+{%- for user,password in {{ principals }} -%}
+  {{ user }} {{ pass }}
+{%- endfor -%}
+EOF | time {{ kadmin_local }} > /dev/null
+
+# Task 3: Remove from KDC method?
+#???? how, why, when ???

--- a/kerberos/install.sls
+++ b/kerberos/install.sls
@@ -1,8 +1,18 @@
 {% from "kerberos/map.jinja" import kerberos with context %}
 
 {% if kerberos.pkg is defined %}
+#legacy pillar structure
+
 kerberos-tools:
   pkg.installed:
     - name: {{ kerberos.pkg }}
+
+{% else %}
+#updated pillar structure or no pillars defined
+
+kerberos-krb5-client:
+  pkg.installed:
+    - name: {{ kerberos.krb5.client }}
+
 {% endif %}
 

--- a/kerberos/kdc.sls
+++ b/kerberos/kdc.sls
@@ -1,0 +1,50 @@
+{% from "kerberos/map.jinja" import kerberos with context %}
+
+{% if grains.os not in ('MacOS', 'Windows',) %}
+
+kerberos_kdc:
+  pkg.installed:
+    - names:
+      - {{ kerberos.kdc.server }}
+      - {{ kerberos.kdc.adm_server }}
+      - {{ kerberos.krb5.client }}
+    - require_in:
+      file: kerberos_kdc
+  file.managed:
+    - name: {{ kerberos.kdc.config }}
+    - source: {{ kerberos.kdc.config_src }}
+    - template: jinja
+    - user: root
+    - group: {{ kerberos.get('krb5:root_group', 'root') }}
+    - mode: 0644
+    - require_in:
+      - file: kerberos_kdc_realms_kprop_acl
+
+kerberos_kdc_realms_kprop_acl:
+  file.managed:
+    - name: {{ kerberos.kdc.kprop_acl_file }}
+    - source: {{ kerberos.kdc.kprop_acl_file_src }}
+    - template: jinja
+    - user: root
+    - group: {{ kerberos.get('krb5:root_group', 'root') }}
+    - mode: 0644
+    - require_in:
+      - file: kerberos_kdc_realms_kadm5_acl
+    - context:
+      default_master: {{ kerberos.kdc.default_master }}
+      default_slave: {{ kerberos.kdc.default_slave or kerberos.kdc.default_master }}
+      default_domain: {{ kerberos.krb5.libdefaults.default_domain }}
+      default_realm: {{ kerberos.krb5.libdefaults.default_realm }}
+
+kerberos_kdc_realms_kadm5_acl:
+  file.managed:
+    - name: {{ kerberos.kdc.realms.acl_file }}
+    - source: {{ kerberos.kdc.kadm5_acl_file_src }}
+    - template: jinja
+    - user: root
+    - group: {{ kerberos.get('krb5:root_group', 'root') }}
+    - mode: 0644
+    - context:
+      default_realm: {{ kerberos.krb5.libdefaults.default_realm }}
+
+{% endif %}

--- a/kerberos/keytab.sls
+++ b/kerberos/keytab.sls
@@ -1,4 +1,12 @@
 {% from "kerberos/map.jinja" import kerberos with context %}
+ 
+#Legacy pillar structure
+{%- set keytabs = salt['pillar.get']('kerberos:keytabs') -%}
+
+#New pillar structure or no pillars
+{% if kerberos.kdc.keytabs %}
+  {%- set keytabs = kerberos.kdc.keytabs -%}
+{% endif %}
 
 /etc/krb5:
   file.directory:
@@ -12,11 +20,12 @@
       - mode
     - makedirs: True
 
-{%- for keytab in salt['pillar.get']('kerberos:keytabs') %}
+{%- for keytab in keytabs %}
 /etc/krb5/{{ keytab }}:
   file.managed:
     - user: root
     - source: salt://kerberos/files/{{ keytab }}
-    - group: {{ kerberos.get('root_group', 'root') }}
+    - group: {{ kerberos.krb5.get('root_group', 'root') }}
     - template: jinja
 {%- endfor %}
+

--- a/kerberos/map.jinja
+++ b/kerberos/map.jinja
@@ -1,8 +1,84 @@
-{% set kerberos = salt['grains.filter_by']({
-    'Debian': {
-        'pkg': 'krb5-user',
-    },
-    'FreeBSD': {
+{% set kdc_osmap = salt['grains.filter_by']({
+     'default': {
+         'server': 'krb5-server',
+         'adm_server': 'krb5-libs',
+         'extras': '',
+         'service': 'krb5kdc',
+         'adm_service': 'kadmin',
+         'config': '/var/kerberos/krb5kdc/kdc.conf',
+         'dict_file': '/usr/share/dict/words',
+     },
+     'Debian': {
+        'server': 'krb5-kdc',
+        'adm_server': 'krb5-admin-server',
+        'extras': ['libkadm55', 'krb5-kdc-ldap', 'krb5-strength', 'openafs-krb5',],
+        'service': 'krb5-kdc',
+        'adm_service': 'krb5-admin-server',
+        'config': '/etc/krb5kdc/kdc.conf',
+        'acl_file': '/etc/krb5kdc/kadm5.acl',
+        'database_name': '/usr/local/var/krb5kdc/principal',
+        'kdb_util_create': 'krb5_newrealm', 
+     },
+     'Suse': {
+        'adm_server': 'krb5',
+        'extras': ['krb5-appl-servers',],
+        'config': '/var/lib/kerberos/krb5kdc/kdc.conf',
+        'libdefaults_default_ccache_name': 'FILE:/tmp/krb5cc_%{uid}',
+     },
+     'gentoo': {
+        'server': 'app-crypt/heimdal',
+        'adm_server': '',
+        'extras': ['net-misc/openssh',],
+        'adm_service': '',
+        'config': '/var/lib/krb5kdc/kdc.conf',
+     },
+     'Arch': {
+        'server': 'krb5',
+        'adm_server': 'krb5',
+        'service': 'krb5-kdc',
+        'adm_service': 'krb5-kadmind',
+        'kprop_service': 'krb5-kpropd',
+        'config': '/var/lib/krb5kdc/kdc.conf',
+        'kprop_config': '/var/lib/krb5kdc/kpropd.acl',
+        'acl_file': '/usr/local/var/krb5kdc/kadm5.acl',
+        'database_name': '/usr/local/var/krb5kdc/principal',
+     },
+}, default='default') %}
+
+#Client
+{% set krb5_osmap = salt['grains.filter_by']({
+     'default': {
+        'client': 'krb5-workstation',
+        'utils': ['pam-krb5',],
+     },
+     'Debian': {
+        'client': 'krb5-user',
+        'utils': ['libpam-krb5', 'libpam-ccreds', 'auth-client-config', 'auth-pkg-config', 'krb5-auth-dialog', 'krb5-otp', 'sssd-krb5', 'krb5-locales',],
+     },
+     'Suse': {
+        'client': 'krb5-pkg',
+        'utils': ['pam_krb5', 'krb5-apps-pkgs', 'krb5-auth-dialog', 'krb5-plugin-kdb-ldap', 'krb5-plugin-preauth-otp', 'krb5-plugin-preauth-pkinit', 'krb5-ticket-watcher',],
+     },
+     'gentoo': {
+        'client': 'app-crypt/mit-krb5-appl',
+        'utils': ['sys-auth/pam_krb5',],
+     },
+     'Arch': {
+        'client': 'krb5',
+        'utils': ['pam-krb5',],
+     },
+     'FreeBSD': {
         'root_group': 'wheel',
-    },
-}, merge=salt['pillar.get']('kerberos:lookup')) %}
+     },
+     'Windows': {
+        'client_config': 'C:\\winnt\\krb5.ini',
+        'default_keytab_name': 'C:\\winnt\krb5\\krb5.keytab',
+     },
+}, default='default') %}
+
+{## start with defaults, merging osmapping and pillars ##}
+{% import_yaml 'kerberos/defaults.yaml' as defs %}
+{% do defs.kerberos.kdc.update( kdc_osmap ) %}
+{% do defs.kerberos.krb5.update( krb5_osmap ) %}
+{% set kerberos = salt['pillar.get']( 'kerberos', default=defs.kerberos, merge=True) %}
+

--- a/pillar.example
+++ b/pillar.example
@@ -1,32 +1,45 @@
+ 
 kerberos:
-  libdefaults:
-    default_realm: ATHENA.MIT.EDU
-    dns_lookup_kdc: yes
-    dns_lookup_realm: yes
+  krb5:
+    libdefaults:
+      default_realm: ATHENA.MIT.EDU
+      default_domain: athena.mit.edu
+      dns_lookup_kdc: yes
+      dns_lookup_realm: yes
   
-  realms:
-    ATHENA.MIT.EDU:
-      kdc:
-        - kerberos.mit.edu
-        - kerberos-1.mit.edu
-        - "kerberos.mit.edu:750"
-      admin_server: kerberos.mit.edu
-      master_kdc: kerberos.mit.edu
+    realms:
+      ATHENA.MIT.EDU:
+        kdc:
+          - kerberos.mit.edu
+          - kerberos-1.mit.edu
+          - "kerberos.mit.edu:750"
+        admin_server: kerberos.mit.edu
+        master_kdc: kerberos.mit.edu
 
-    EXAMPLE.COM:
-      kdc:
-        - kerberos.example.com
-        - kerberos-1.example.com
-      admin_server: kerberos.example.com
+      EXAMPLE.COM:
+        kdc:
+          - kerberos.example.com
+          - kerberos-1.example.com
+        admin_server: kerberos.example.com
  
-  domain_realm:
-    mit.edu: ATHENA.MIT.EDU
+    domain_realm:
+      .mit.edu: ATHENA.MIT.EDU
+      mit.edu: ATHENA.MIT.EDU
+      .example.com: EXAMPLE.COM
+      example.com: EXAMPLE.COM
  
-  capaths:
-    ATHENA.MIT.EDU:
-      EXAMPLE.COM: .
-    EXAMPLE.COM:
-      ATHENA.MIT.EDU: .
+    capaths:
+      ATHENA.MIT.EDU:
+        EXAMPLE.COM: .
+      EXAMPLE.COM:
+        ATHENA.MIT.EDU: .
 
-  keytabs:
-    - http.keytab
+  kdc:
+    default_master: kerberos.mit.edu
+    default_slave: kerberos-slave.mit.edu
+    logging:
+      kdc: 'FILE:/var/log/krb5kdc.log'
+
+    keytabs:
+      - dummy.keytab
+


### PR DESCRIPTION
This PR introduces formula enhancements to part-implement #1 and facilitate #2 and other future enhancements which community might desire.  This PR implements the following- 

1. basic support for Kerberos V5 Domain Controller (KDC) = New State.
2. New pillar structure (for extensibility)
3. Adopt states so they continue to work with existing pillars (i.e. backwards compat)
4. New defaults.yaml with good (MIT, Heimdal) defaults and extensible structure.
5. Update map.jinja accordingly
6. Add "no pillars" support - current formula has hard dependency.

This formula is tested successfully with and without pillars on Centos7.  Existing states work, and new kerberos.kdc state successfully implements parts of #1 

**Verification logs**
-  with pillars: [kerberos-cent7.log](https://github.com/saltstack-formulas/kerberos-formula/files/1500239/kerberos-cent7.log)
- no pillars:  [kerberos-cent7-nopillars.log](https://github.com/saltstack/salt/files/1500265/kerberos-cent7-nopillars.log)

**Note:**  The errors/warnings are salt issue.
`Exception raised when processing __virtual__ function for salt.loaded.int.module.ansiblegate.`