### PR TITLE
prevent possible kerberos library failure

### DIFF
--- a/kerberos/defaults.yaml
+++ b/kerberos/defaults.yaml
@@ -6,6 +6,7 @@ kerberos:
     libdefaults:
       default_realm: EXAMPLE.COM
       default_domain: example.com
+      rdns: false
     realms:
       EXAMPLE.COM:
         kdc:


### PR DESCRIPTION
Make `rdns = false` an explicit formula default to help avoid this error.

> ldap_sasl_interactive_bind_s: Local error (-2) additional info: SASL(-1): generic failure: GSSAPI Error: Unspecified GSS failure.  Minor code may provide more information (Server not found in Kerberos database)

From: https://access.redhat.com/solutions/2069253

> Setting rdns = false in /etc/krb5.conf ensures that the Kerberos library accepts the input hostname instead of looking up the hostname via DNS based on the host's IP address, preventing possible Kerberos library failure.