### PR TITLE
Workaround kerberos regression in Citrix LinuxVDA

### DIFF
--- a/kerberos/files/kdc.conf
+++ b/kerberos/files/kdc.conf
@@ -71,97 +71,97 @@
 # the krb5kdc and kadmind daemons. Uses same format as krb5.conf file.
 
 #====================== kdcdefaults ==============================
-;[kdcdefaults]
+#;[kdcdefaults]
 # Default values for KDC behavior
 #
 # Lists ports the Kerberos server should listen for UDP requests,
 # as comma-separated list of integers. The default value is 88, 750,
 # the assigned Kerberos port and port historically used by Kerberos V4.
-;kdc_ports = 88,750
+#;kdc_ports = 88,750
 #
 # Lists ports the Kerberos server should listen for TCP connections,
 # as a comma-separated list of integers. If not specified, the
 # compiled-in default is not to listen for TCP connections at all.
-;kdc_tcp_ports = 88,750
+#;kdc_tcp_ports = 88,750
 #
 # Name of the principal associated with the master key.
-;master_key_name = K/M
+#;master_key_name = K/M
 #
 # Specifies the master keys key type.
-;master_key_type = aes256-cts-hmac-sha1-96
+#;master_key_type = aes256-cts-hmac-sha1-96
 #
 # KDC to reject ticket requests from anonymous principals to service
 # principals other than realms ticket-granting service (def: false).
-;restrict_anonymous_to_tgt = false
+#;restrict_anonymous_to_tgt = false
 #
 #How the KDC should respond to Kerberos 4 packets. Supported values
 # are none, disable, full, and nopreauth. Default value is none.
-;v4_mode = none
+#;v4_mode = none
 #
 #======================= realms ==================================
-;[realms]
+#;[realms]
 # Realm-specific database configuration and settings
-;EXAMPLE.COM = {
-;      kdc_ports = 88
-;      kadmind_port = 749
-;      max_life = 12h 0m 0s
-;      max_renewable_life = 7d 0h 0m 0s
-;      master_key_type = des3-hmac-sha1
-;      default_principal_flags = +preauth
-;      supported_enctypes = arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
+#;EXAMPLE.COM = {
+#;      kdc_ports = 88
+#;      kadmind_port = 749
+#;      max_life = 12h 0m 0s
+#;      max_renewable_life = 7d 0h 0m 0s
+#;      master_key_type = des3-hmac-sha1
+#;      default_principal_flags = +preauth
+#;      supported_enctypes = arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
 #      If the default location does not suit your setup,
 #      explicitly configure the values below. Ensure write
 #      permission on the target directories (which must exist)
-;      #    admin_keytab = /etc/krb5/kadm5.keytab
-;      #    database_name = /var/kerberos/krb5kdc/principal
-;      #    acl_file = /var/kerberos/krb5kdc/kadm5.acl
-;      #    key_stash_file = /var/kerberos/krb5kdc/stash
-;}
+#;      #    admin_keytab = /etc/krb5/kadm5.keytab
+#;      #    database_name = /var/kerberos/krb5kdc/principal
+#;      #    acl_file = /var/kerberos/krb5kdc/kadm5.acl
+#;      #    key_stash_file = /var/kerberos/krb5kdc/stash
+#;}
 #
 #
 #====================== dbdefaults ===============================
-;[dbdefaults]
+#;[dbdefaults]
 # Default database settings
-;ldap_kerberos_container_dn = cn=krbcontainer, dc=example, dc=com
-;ldap_kerberos_container_dn = cn=krbcontainer, dc=hadoop, dc=example, dc=com
+#;ldap_kerberos_container_dn = cn=krbcontainer, dc=example, dc=com
+#;ldap_kerberos_container_dn = cn=krbcontainer, dc=hadoop, dc=example, dc=com
 #
 #
 #====================== dbmodules ================================
-;[dbmodules]
+#;[dbmodules]
 # Per-database settings
-;   openldap_ldapconf = {
-;       db_library = kldap
-;       disable_last_success = true
-;       ldap_kdc_dn = "cn=krbadmin,dc=example,dc=com"
-;           # this object needs to have read rights on
-;           # the realm container and principal subtrees
-;       ldap_kadmind_dn = "cn=krbadmin,dc=example,dc=com"
-;           # this object needs to have read and write rights on
-;           # the realm container and principal subtrees
-;       ldap_service_password_file = /etc/kerberos/service.keyfile
-;       ldap_servers = ldaps://kerberos1.example.com
-;       ldap_conns_per_server = 5
-;   }
+#;   openldap_ldapconf = {
+#;       db_library = kldap
+#;       disable_last_success = true
+#;       ldap_kdc_dn = "cn=krbadmin,dc=example,dc=com"
+#;           # this object needs to have read rights on
+#;           # the realm container and principal subtrees
+#;       ldap_kadmind_dn = "cn=krbadmin,dc=example,dc=com"
+#;           # this object needs to have read and write rights on
+#;           # the realm container and principal subtrees
+#;       ldap_service_password_file = /etc/kerberos/service.keyfile
+#;       ldap_servers = ldaps://kerberos1.example.com
+#;       ldap_conns_per_server = 5
+#;   }
 #
 #
 #====================== logging ==================================
-;[logging]
+#;[logging]
 # Controls how Kerberos daemons perform logging. By default, KDC
 # and kadmind log using syslog. You can override here.
-;   kdc = CONSOLE
-;   kdc = SYSLOG:INFO:DAEMON
-;   kdc = FILE:/var/log/krb5kdc.log
-;   admin_server = FILE:/var/log/kadmin.log
-;   admin_server = DEVICE=/dev/tty04
-;   default = FILE:/var/log/krb5lib.log
+#;   kdc = CONSOLE
+#;   kdc = SYSLOG:INFO:DAEMON
+#;   kdc = FILE:/var/log/krb5kdc.log
+#;   admin_server = FILE:/var/log/kadmin.log
+#;   admin_server = DEVICE=/dev/tty04
+#;   default = FILE:/var/log/krb5lib.log
 #
 #==========================otp ==================================
-;[otp]
+#;[otp]
 # Support for onetime password requests. MIT Kerberos only
-;  MyRemoteTokenType = {
-;      # Server to send the RADIUS request to.
-;      server =
-;      timeout =
-;      retries = 3
-;      strip_realm = true
-;  }
+#;  MyRemoteTokenType = {
+#;      # Server to send the RADIUS request to.
+#;      server =
+#;      timeout =
+#;      retries = 3
+#;      strip_realm = true
+#;  }

--- a/kerberos/files/krb5.conf
+++ b/kerberos/files/krb5.conf
@@ -87,297 +87,297 @@
 #
 #===================== libdefaults ================================
 # Contains default values used by the Kerberos V5 library.
-;[libdefaults]
+#;[libdefaults]
 #
 # Default/local realm
-;default_realm = EXAMPLE.COM
+#;default_realm = EXAMPLE.COM
 #
 # Allow weak crypto algorithms
-;allow_weak_crypto = false
+#;allow_weak_crypto = false
 #
 # Max time differential between KDC and app servers (default 5m)
-;clockskew = 300
+#;clockskew = 300
 #
 # Maximum wait time for reply from kdc, default 3 seconds.
-;kdc_timeout = 3
+#;kdc_timeout = 3
 #
 # The keytab to use if no other is specified.
-;default_keytab_name = FILE:/etc/krb5.keytab
+#;default_keytab_name = FILE:/etc/krb5.keytab
 #
 # Behind a NAT, you may want to set to the NAT's public address
-;extra_addresses = ip.address.of.nat
+#;extra_addresses = ip.address.of.nat
 #
 # Obtain forwardable tickets for inital credentials (def: false)
-;forwardable = true
+#;forwardable = true
 #
 # Try to compensate for time diff between local machine and KDC.
-;kdc_timesync = true
+#;kdc_timesync = true
 #
 # Do not use DNS TXT records to lookup domain-realm mappings.
-;dns_lookup_kdc = true
-;dns_lookup_realm = false
+#;dns_lookup_kdc = true
+#;dns_lookup_realm = false
 #
 # For initial credentials, make credentials proxiable (def: false)
-;proxiable = true
+#;proxiable = true
 #
 # Enable if all KDC's are heimdal 0.6 or later (def: true)
 # or if you are behind a NAT (probably true).
-;no-addresses = true
+#;no-addresses = true
 #
 # Default ticket lifetime to request (max: 1y?)
-;ticket_lifetime = 1d
+#;ticket_lifetime = 1d
 #
 # Default renewable ticket lifetime.
-;renew_lifetime = 7d
+#;renew_lifetime = 7d
 #
 # Don't try to convert V4 instances to V5 using DNS resolution
-;v4_instance_resolve = false
+#;v4_instance_resolve = false
 #
 # Fail to verify inital credentials if client machine has no
 # keytab. Some applications, like su(1), enable this anyway.
-;verify_ap_req_nofail = false
+#;verify_ap_req_nofail = false
 #
 ###### Java (JAAS) Kerberos ###########
 # By default, the Java Kerberos configuration uses the UDP
 # protocol. Otherwise the TCP protocol is used only if the
 # ticket request over UDP fails with KRB_ERR_RESPONSE_TOO_BIG.
 # To use TCP protocol as default specify '1' here.
-;udp_preference_limit =
+#;udp_preference_limit =
 #
 ###### HEIMDAL Kerberos only
 # Enable if all KDC's are heimdal 0.6 or later (def: true)
 # or if you are behind a NAT (probably true).
-;noaddresses = true
+#;noaddresses = true
 #
 # sets the default credentials type (Heimdal Kerberos)
-;default_cc_type = 4
+#;default_cc_type = 4
 #
 # sets default credentials cache name (Heimdal Kerberos).
-;default_cc_name =
+#;default_cc_name =
 #
 # Override default encryption types. But this only serves to
 # disable new encryption types resulting in interop problems.
-;default_etypes =
-;default_as_etypes =
-;default_tgs_etypes =
+#;default_etypes =
+#;default_as_etypes =
+#;default_tgs_etypes =
 #
 # Parameter v4_name_convert is valid for Heidmal only.
 # See krb5_425_conv_principal(3) manual page.
-;v4_name_convert = {
-;    host = {
-;        rcmd    = host
-;        ftp     = ftp
-;        imap    = imap
-;        pop     = pop
-;        lmtp    = lmtp
-;        mupdate = mupdate
-;    }
-;    plain = {
-;        ftp    = ftp
-;        rcmd   = host
-;        hprop  = hprop
-;        iprop  = iprop
-;        ldap   = ldap 
-;        smtp   = smtp 
-;    }
+#;v4_name_convert = {
+#;    host = {
+#;        rcmd    = host
+#;        ftp     = ftp
+#;        imap    = imap
+#;        pop     = pop
+#;        lmtp    = lmtp
+#;        mupdate = mupdate
+#;    }
+#;    plain = {
+#;        ftp    = ftp
+#;        rcmd   = host
+#;        hprop  = hprop
+#;        iprop  = iprop
+#;        ldap   = ldap 
+#;        smtp   = smtp 
+#;    }
 #
 #Set to true for Heimdal 0.6 or earlier
-;fcc-mit-ticketflags = false
+#;fcc-mit-ticketflags = false
 #
 # The max number of times to try to contact each KDC.
-;max_retries = number
+#;max_retries = number
 #
 # How soon to warn for expiring password. Default 7-days.
-;warn_pwexpire = time
+#;warn_pwexpire = time
 #
 # Write log-entries using UTC instead of local time zone.
-;log_utc = false
+#;log_utc = false
 #
 # When deciding what addresses to ask for in a ticket, list
 # addresses belonging to any interface on this host.
-;scan_interfaces = true
+#;scan_interfaces = true
 #
 # Use file credential cache format version specified. On
 # machines running old Oracle krb5 code, uncomment this,
-;fcache_version = 3
+#;fcache_version = 3
 #
 #
 ###### MIT Kerberos only
 # Accept diff client principals than requested (def: false)
-;canonicalize = false
+#;canonicalize = false
 #
 # sets the default credentials type.
-;ccache_type = 4
+#;ccache_type = 4
 #
-; Default KDC options (Xored) (def: 0x00000010, KDC_OPT_RENEWABLE_OK)
-;kdc_default_options = 0x00000010
+#; Default KDC options (Xored) (def: 0x00000010, KDC_OPT_RENEWABLE_OK)
+#;kdc_default_options = 0x00000010
 #
 # sets default credentials cache name.
-;default_ccache_name = FILE:/tmp/krb5cc_%{uid}
+#;default_ccache_name = FILE:/tmp/krb5cc_%{uid}
 #
 # name of default keytab for getting client credentials.
-;default_client_keytab_name = FILE:/var/kerberos/krb5/user/%{euid}/client.keytab
+#;default_client_keytab_name = FILE:/var/kerberos/krb5/user/%{euid}/client.keytab
 #
 # The following encryption types are used by MIT Kerberos if set.
 # However MIT defaults are generally correct so overriding
 # only disables new encryption types, creating interop problems.
-;default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4
-;default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4
-;permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4
+#;default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4
+#;default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4
+#;permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4
 #
-;dns_canonicalize_hostname = true
+#;dns_canonicalize_hostname = true
 #
-;kcm_mach_service = org.h5l.kcm
-;kcm_socket = /var/run/.heim_org.h5l.kcm-socket
+#;kcm_mach_service = org.h5l.kcm
+#;kcm_socket = /var/run/.heim_org.h5l.kcm-socket
 #
-;EXAMPLE.COM = {
-;  pkinit_anchors = FILE:/usr/local/example.com.crt
-; }
-;pkinit_anchors = DIR:/usr/local/generic_trusted_cas/
+#;EXAMPLE.COM = {
+#;  pkinit_anchors = FILE:/usr/local/example.com.crt
+#; }
+#;pkinit_anchors = DIR:/usr/local/generic_trusted_cas/
 #
 #
 #================ login section =======================
 # Referenced by MIT kerberos v5 web docs but omitted
 # from krb5.conf(5) man page. Not documented by Heimdal.
-;[login]
+#;[login]
 # Use user's password to get V5 tickets (def: true)
-;krb5_get_tickets = true
+#;krb5_get_tickets = true
 # Use user's password to get V4 tickets (def: false)
-;krb4_get_tickets = false
+#;krb4_get_tickets = false
 # Use Kerberos conversion daemon to get V4 tickets (def: false)
-;krb4_convert = false
+#;krb4_convert = false
 # Run aklog (def: false) 
-;krb_run_aklog = false
+#;krb_run_aklog = false
 # Location of aklog (default value is $(prefix)/bin/aklog )
-;aklog_path =
+#;aklog_path =
 # True causes login to reject plaintext passwords (def: false)
-;accept_passwd = false-not-implemented-yet
+#;accept_passwd = false-not-implemented-yet
 #
 #
 #================ appdefaults section =====================
 # Contains default values usable by Kerberos V5 applications.
-;[appdefaults]
+#;[appdefaults]
 #
 # MIT Kerberos advise you to review application man pages,
 # noting defaults here may be overridden in [realms] section.
 # Meanwhile Heimdal Kerberos documents the following-
 #
-;    pam: {
+#;    pam: {
 #       Default ticket lifetime to request (max: 1y?)
-;       ticket_lifetime = 1d
+#;       ticket_lifetime = 1d
 #
 #       Default renewable ticket lifetime.
-;       renew_lifetime = 1d
+#;       renew_lifetime = 1d
 #
 ##       Obtain forwardable tickets on inital credentials (def: false)
-;       forwardable = true
+#;       forwardable = true
 #
 #       For initial credentials, make them proxiable (def: false)
-;       proxiable = false
+#;       proxiable = false
 #
 #       Are tickets valid from any address for initial creds. Enable
 #       if all KDC's are heimdal 0.6 or ipaddress is NAT'ed.
-;       no-addresses = true
+#;       no-addresses = true
 #
 #       Use encryption when available; Heidmal.
-;       encrypt = true
+#;       encrypt = true
 #
 #       Forward creds to remote host (rsh, telnet, etc); Heidmal.
-;       forward = true
+#;       forward = true
 #
-;       retain_after_close = false
-;       debug = false
-;       minimum_uid = 0
-;    }
+#;       retain_after_close = false
+#;       debug = false
+#;       minimum_uid = 0
+#;    }
 #
 #==================== realms ===============================
-;[realms]
+#;[realms]
 # Each tag names a Kerberos realm with relations defining
 # the properties of that particular realm. The following
 # tags may be specified in the realm's subsection:
 #
-;EXAMPLE.COM {
+#;EXAMPLE.COM {
 #    Name of host running kerberos administration server.
-;    admin_server = kerberos1.example.com
+#;    admin_server = kerberos1.example.com
 #
 #    This breaks krb4 compatibility but increases security
-;    default_principal_flags = +preauth
+#;    default_principal_flags = +preauth
 #
 #    Name of master KDC. Used if credentials fail (maybe
 #    caused by "slow password-change propagation").
-;    master_kdc = kerberos1.example.com
+#;    master_kdc = kerberos1.example.com
 #
 #    Name of host(s) running a kdc for this realm.
-;    kdc = kerberos1.example.com
-;    kdc = kerberos2.example.com
-;    kdc = kerberos3.example.com
-;    kdc = kerberos4.example.com
+#;    kdc = kerberos1.example.com
+#;    kdc = kerberos2.example.com
+#;    kdc = kerberos3.example.com
+#;    kdc = kerberos4.example.com
 #
 #    Used for Kerberos 4 compatibility and translation.
-;    default_domain = example.com
+#;    default_domain = example.com
 #
 #    Exceptions to default_domain mapping rule. Contains V4
 #    instances (tag name) translating to specific hostname (tag
 #    value) as second component in a Kerberos V5 principal name.
-;    v4_instance_convert = {
-;                kerberos = kerberos
-;                computer = computer.some.other.domain
-;             }
+#;    v4_instance_convert = {
+#;                kerberos = kerberos
+#;                computer = computer.some.other.domain
+#;             }
 #
 #    Used by krb524 library converting from V5 to V4 principal
 #    names. The tag value is the Kerberos V4 realm name.
-;    v4_realm = kerberos.olddomain.example.com
+#;    v4_realm = kerberos.olddomain.example.com
 #
 #    General rules mapping principal names to local user names
-;    auth_to_local = {
-;                 RULE:[2:$1](johndoe)s/^.*$/guest/
-;                 RULE:[2:$1;$2](^.*;admin$)s/;admin$//
-;                 RULE:[2:$2](^.*;root)s/^.*$/root/
-;                 DEFAULT
-;                 }
+#;    auth_to_local = {
+#;                 RULE:[2:$1](johndoe)s/^.*$/guest/
+#;                 RULE:[2:$1;$2](^.*;admin$)s/;admin$//
+#;                 RULE:[2:$2](^.*;root)s/^.*$/root/
+#;                 DEFAULT
+#;                 }
 #
 #    Explicit mappings from principal names to local user names
-;    auth_to_local_names = {
-;                 }
+#;    auth_to_local_names = {
+#;                 }
 #
 #    Host where password changes occur (def: <adm_server>:464)
-;    kpasswd_server = kerberos.example.com:464
-;}
+#;    kpasswd_server = kerberos.example.com:464
+#;}
 #
-;HADOOP.EXAMPLE.COM = {
-;    admin_server = kerberos1.hadoop.example.com
-;    kdc = kerberos1.hadoop.example.com
-;    kdc = kerberos2.hadoop.example.com
-;    default_domain = example.com
-;    pkinit_anchors = FILE:/usr/local/otherrealm.org.crt
-;}
+#;HADOOP.EXAMPLE.COM = {
+#;    admin_server = kerberos1.hadoop.example.com
+#;    kdc = kerberos1.hadoop.example.com
+#;    kdc = kerberos2.hadoop.example.com
+#;    default_domain = example.com
+#;    pkinit_anchors = FILE:/usr/local/otherrealm.org.crt
+#;}
 #
 #
 #======================== domain_realm ======================
-;[domain_realm]
+#;[domain_realm]
 # Maps domain name or hostname to Kerberos realm name.
-;.example.com = EXAMPLE.COM
-;example.com = EXAMPLE.COM
-;.hadoop.example.com = HADOOP.EXAMPLE.COM
-;hadoop.example.com = HADOOP.EXAMPLE.COM
+#;.example.com = EXAMPLE.COM
+#;example.com = EXAMPLE.COM
+#;.hadoop.example.com = HADOOP.EXAMPLE.COM
+#;hadoop.example.com = HADOOP.EXAMPLE.COM
 #
 #
 #========================== plugins =========================
-;[plugins]
+#;[plugins]
 # Referenced in MIT Kerberos krb5.conf(5) man page.
 # Controls dynamic plugin module registration.
 #
 #========================== kadmin ==========================
 # Documented in Hemidal krb5.conf(5). Omitted by MIT man page.
-;[kadmin]
+#;[kadmin]
 # Is pre-authentication required to talk to kadmin server?
-;require-preauth = false
+#;require-preauth = false
 # If a principal already has its password set for expiration,
 # this is how long it remains valid after a change.
-;password_lifetime = 7d
+#;password_lifetime = 7d
 #
 #========================== capaths =========================
-;[capaths]
+#;[capaths]
 # For direct (non-hierarchical) cross-realm authentication,
 # a database is required to construct authentication paths
 # between the realms. This section defines that database.


### PR DESCRIPTION
This PR is a workaround for regression in Citrix LinuxVDA 18.11

In Kerberos standard a kbr5.conf comment may start with ";"  but thats broken in LinuxVDA 18.11.07-1

`LDAPSearch.GETKerberosAgentClientSubject: Unable to obtain LDAP Login Context for 'agent.client'. Error: Illegal config context:;[libdefaults].`

However Internet agrees ';' is valid-
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8160518
https://bugs.openjdk.java.net/browse/JDK-8160518
https://github.com/JetBrains/jdk8u_jdk/commit/a7e8f2e7e8cfc26f955cfea739533f60a1cfd263

